### PR TITLE
Add a "Download for Linux" button to the front-page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,7 +7,7 @@ import styles from './index.module.scss';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import { downloadLinks } from '../utils/helper';
 import QuickStart from '../components/QuickStart';
-import { FaApple, FaWindows } from 'react-icons/fa';
+import { FaApple, FaWindows, FaLinux } from 'react-icons/fa';
 
 function HomepageHeader() {
   useEffect(() => {
@@ -55,6 +55,15 @@ function HomepageHeader() {
               >
                 <FaApple />
                 <span className="">Download For Mac</span>
+              </Link>
+            </div>
+            <div className="rounded-full bg-accent1 transition duration-300 ease-in-out  hover:bg-accent1-hover ">
+              <Link
+                className="flex items-center gap-2 p-4 text-xl font-bold uppercase tracking-wider text-white hover:text-white hover:no-underline dark:text-black hover:dark:text-black"
+                to={downloadLinks.linux}
+              >
+                <FaLinux />
+                <span className="">Download For Linux</span>
               </Link>
             </div>
           </div>

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -1,5 +1,6 @@
 export const downloadLinks = {
   windows: '/getting-started/install/?platform=windows',
   mac: '/getting-started/install/?platform=unix',
+  linux: '/getting-started/install/?platform=unix',
 };
 export const GitHubNodeRepo = 'https://github.com/flojoy-io/nodes/tree/main';


### PR DESCRIPTION
When looking at [Flojoy's front-page](https://www.flojoy.ai/), I thought Flojoy was not available for Linux eventhough it actually is!

This PR proposes adding a "Download for Linux" button to the front-page.

This renders as follows:

![Screenshot 2023-08-25 at 11-37-28 Flojoy Documentation Flojoy](https://github.com/flojoy-ai/docs/assets/13029839/26997839-5c1f-4c82-916d-00e09f0e7989)
