### PR TITLE
fixed syntax for instrument code snippets

### DIFF
--- a/docs/instruments-database/Lockin Amplifiers/M2j/M2j.md
+++ b/docs/instruments-database/Lockin Amplifiers/M2j/M2j.md
@@ -69,6 +69,62 @@ except ImportError:
 class M2j(Instrument):
     # The code for the M2j class is provided in the question
 
+    def __init__(self, name: str, spi_rack: SPI_rack, module: int, **kwargs):
+    """
+    Qcodes driver for the M2j RF amplifier SPI-rack module.
+
+    Args:
+        name: name of the instrument.
+
+        spi_rack: instance of the SPI_rack class as defined in
+            the spirack package. This class manages communication with the
+            individual modules.
+
+        module: module number as set on the hardware.
+
+    The gain can only be set on the device, but not read from the device.
+    """
+    super().__init__(name, **kwargs)
+
+    self.m2j = M2j_module(spi_rack, module)
+    self._max_gain_value = 4095
+    self._min_gain_value = 0
+    self._gain_parameters = {'slope': -1024.45, 'offset': 4450.63,
+                                 'db_offset': 32}
+
+    self.add_parameter('gain',
+                           label='gain',
+                           set_cmd=self._set_gain,
+                           unit='dB',
+                           vals=Numbers(min_value=33, max_value=110),
+                           docstring='Amplifier gain in dB, range 33 to 110 dB')
+
+    self.add_parameter('RF_level',
+                           label='RF level',
+                           get_cmd=self._meas_rf_level,
+                           unit='dBm',
+                           docstring='Measured RF power after amplification '
+                                     '(not calibrated)')
+
+    self.add_function('clear_rf_clip',
+                          call_cmd=self.m2j.clear_rf_clip)
+    self.add_function('is_rf_clipped',
+                          call_cmd=self.m2j.rf_clipped)
+
+    def _set_gain(self, gain):
+        ref_scale = int(self._gain_parameters['slope'] * np.log(
+            gain - self._gain_parameters['db_offset']) + self._gain_parameters[
+                            'offset'])
+        if ref_scale < self._min_gain_value:
+            ref_scale = self._min_gain_value
+        if ref_scale > self._max_gain_value:
+            ref_scale = self._max_gain_value
+
+        self.m2j.set_gain(ref_scale)
+
+    def _meas_rf_level(self):
+        return self.m2j.get_level()
+
 
 # Create an instance of the SPI_rack class
 spi_rack = SPI_rack()
@@ -77,10 +133,10 @@ spi_rack = SPI_rack()
 m2j = M2j('m2j', spi_rack, module=1)
 
 # Set the gain of the amplifier
-m2j.gain(50)
+m2j._set_gain(50)
 
 # Get the RF level after amplification
-rf_level = m2j.RF_level()
+rf_level = m2j._meas_rf_level()
 print(f"RF level: {rf_level} dBm")
 
 # Clear RF clip

--- a/docs/instruments-database/Multimeters/DMM6500/DMM6500.md
+++ b/docs/instruments-database/Multimeters/DMM6500/DMM6500.md
@@ -63,11 +63,160 @@ from .Keithley_2000_Scan import Keithley_2000_Scan_Channel
 
 
 class Keithley_Sense(InstrumentChannel):
-    # ... (code omitted for brevity)
+    """
+    This is the class for a measurement channel, i.e. the quantity to be measured (e.g. resistance, voltage).
+    """
+    def __init__(self, parent: VisaInstrument, name: str, channel: str) -> None:
+        """
+
+        Args:
+            parent: VisaInstrument instance of the Keithley Digital Multimeter
+            name: Channel name (e.g. 'CH1')
+            channel: Name of the quantity to measure (e.g. 'VOLT' for DC voltage measurement)
+        """
+        valid_channels = ['VOLT', 'CURR', 'RES', 'FRES', 'TEMP']
+        if channel.upper() not in valid_channels:
+            raise ValueError(f"Channel must be one of the following: {', '.join(valid_channels)}")
+        super().__init__(parent, name)
+
+        self.add_parameter('measure',
+                           unit=self._get_unit(channel),
+                           label=self._get_label(channel),
+                           get_parser=float,
+                           get_cmd=partial(self.parent._measure, channel),
+                           docstring="Measure value of chosen quantity (Current/Voltage/Resistance/Temperature)."
+                           )
+
+        self.add_parameter('nplc',
+                           label='NPLC',
+                           get_parser=float,
+                           get_cmd=f"SENS:{channel}:NPLC?",
+                           set_cmd=f"SENS:{channel}:NPLC {{:.4f}}",
+                           vals=Numbers(0.0005, 12),
+                           docstring="Integration rate (Number of Power Line Cycles)"
+                           )
+
+    @staticmethod
+    def _get_unit(quantity: str) -> str:
+        """
+
+        Args:
+            quantity: Quantity to be measured
+
+        Returns: Corresponding unit string
+
+        """
+        channel_units = {'VOLT': 'V', 'CURR': 'A', 'RES': 'Ohm', 'FRES': 'Ohm', 'TEMP': 'C'}
+        return channel_units[quantity]
+
+    @staticmethod
+    def _get_label(quantity: str) -> str:
+        """
+
+        Args:
+            quantity: Quantity to be measured
+
+        Returns: Corresponding parameter label
+
+        """
+        channel_labels = {'VOLT': 'Measured voltage.',
+                          'CURR': 'Measured current.',
+                          'RES': 'Measured resistance',
+                          'FRES': 'Measured resistance (4w)',
+                          'TEMP': 'Measured temperature'}
+        return channel_labels[quantity]
 
 
 class Keithley_6500(VisaInstrument):
-    # ... (code omitted for brevity)
+    """
+    This is the qcodes driver for a Keithley DMM6500 digital multimeter.
+    """
+    def __init__(self, name: str,
+                 address: str,
+                 terminator="\n",
+                 **kwargs):
+        """
+        Initialize instance of digital multimeter Keithley6500. Check if scanner card is inserted.
+        Args:
+            name: Name of instrument
+            address: Address of instrument
+            terminator: Termination character for SCPI commands
+            **kwargs: Keyword arguments to pass to __init__ function of VisaInstrument class
+        """
+        super().__init__(name, address, terminator=terminator, **kwargs)
+        for quantity in ['VOLT', 'CURR', 'RES', 'FRES', 'TEMP']:
+            channel = Keithley_Sense(self, quantity.lower(), quantity)
+            self.add_submodule(quantity.lower(), channel)
+
+        self.add_parameter('active_terminal',
+                           label='active terminal',
+                           get_cmd="ROUTe:TERMinals?",
+                           docstring="Active terminal of instrument. Can only be switched via knob on front panel.")
+
+        self.add_parameter('resistance',
+                           unit='Ohm',
+                           label='Measured resistance',
+                           get_parser=float,
+                           get_cmd=partial(self._measure, 'RES'),
+                           )
+
+        self.add_parameter('resistance_4w',
+                           unit='Ohm',
+                           label='Measured resistance',
+                           get_parser=float,
+                           get_cmd=partial(self._measure, 'FRES')
+                           )
+
+        self.add_parameter('voltage_dc',
+                           unit='V',
+                           label='Measured DC voltage',
+                           get_parser=float,
+                           get_cmd=partial(self._measure, 'VOLT')
+                           )
+
+        self.add_parameter('current_dc',
+                           unit='A',
+                           label='Measured DC current',
+                           get_parser=float,
+                           get_cmd=partial(self._measure, 'CURR')
+                           )
+
+        self.add_parameter('temperature',
+                           unit='C',
+                           label='Measured temperature',
+                           get_parser=float,
+                           get_cmd=partial(self._measure, 'TEMP')
+                           )
+
+        self.connect_message()
+
+        # check if scanner card is connected
+        # If no scanner card is connected, the query below returns "Empty Slot".
+        # For the Scanner Card 2000-SCAN used for development of this driver the output was
+        # "2000,10-Chan Mux,0.0.0a,00000000".
+        scan_idn_msg = self.ask(":SYSTem:CARD1:IDN?")
+        if scan_idn_msg != "Empty Slot":
+            msg_parts = scan_idn_msg.split(",")
+            print(f"Scanner card {msg_parts[0]}-SCAN detected.")
+            for ch_number in range(1, 11):
+                scan_channel = Keithley_2000_Scan_Channel(self, ch_number)
+                self.add_submodule(f"ch{ch_number:d}", scan_channel)
+
+    # only measure if front terminal is active
+    def _measure(self, quantity: str) -> str:
+        """
+        Measure given quantity at front terminal of the instrument. Only perform measurement if front terminal is
+        active. Send SCPI command to measure and read out given quantity.
+        Args:
+            quantity: Quantity to be measured
+
+        Returns: Measurement result
+
+        """
+        if self.active_terminal.get() == 'FRON':
+            return self.ask(f"MEAS:{quantity}?")
+        else:
+            raise RuntimeError("Rear terminal is active instead of front terminal.")
 
 
 # Create an instance of the DMM6500 Multimeter

--- a/docs/instruments-database/Network Analyzers/S5048-2-Port-4.8-GHz-Analyzer/S5048-2-Port-4.8-GHz-Analyzer.md
+++ b/docs/instruments-database/Network Analyzers/S5048-2-Port-4.8-GHz-Analyzer/S5048-2-Port-4.8-GHz-Analyzer.md
@@ -55,15 +55,351 @@ The S5048 Vector Network Analyzer delivers lab grade performance in a compact pa
 To connect to a S5048 2-Port 4.8 GHz Analyzer Network Analyzer using Qcodes Community, you can use the following Python script:
 
 ```python
+from typing import Union
+from functools import partial
+import logging
+
+import numpy as np
+
 from qcodes.instrument.visa import VisaInstrument
 from qcodes.instrument.parameter import ArrayParameter
 import qcodes.utils.validators as vals
 
+log = logging.getLogger(__name__)
+
+_unit_map = {'Log Mag': 'dB',
+             'Phase': 'degree',
+             'Group Delay': None,
+             'Smith': 'dim. less',
+             'Polar': 'dim. less',
+             'Lin mag': 'dim. less',
+             'Real': None,
+             'Imag': None,
+             'SWR': 'dim. less'}
+
+
+
+def CMTIntParser(value: str) -> int:
+    """
+    Small custom parser for ints
+
+    Args:
+        value: the VISA return string using exponential notation
+    """
+    return int(float(value))
+
+
+
+class TraceNotReady(Exception):
+    pass
+
+
 class CMTS5048Trace(ArrayParameter):
-    # ... (code omitted for brevity)
+    """
+    Class to hold a the trace from the S5048 network analyzer
+
+    Although the trace can have two values per frequency, this
+    class only returns the first value
+    """
+
+    def __init__(self, name, instrument):
+        super().__init__(name=name,
+                         shape=(1,),  # is overwritten by prepare_trace
+                         label='',  # is overwritten by prepare_trace
+                         unit='',  # is overwritten by prepare_trace
+                         setpoint_names=('Frequency',),
+                         setpoint_labels=('Frequency',),
+                         setpoint_units=('Hz',),
+                         snapshot_get=False
+                         )
+
+        self._instrument = instrument
+
+
+    def prepare_trace(self):
+        """
+        Update setpoints, units and labels
+        """
+
+        # we don't trust users to keep their fingers off the front panel,
+        # so we query the instrument for all values
+
+        fstart = self._instrument.start_freq()
+        fstop = self._instrument.stop_freq()
+        npts = self._instrument.trace_points()
+
+        sps = np.linspace(fstart, fstop, npts)
+        self.setpoints = (tuple(sps),)
+        self.shape = (len(sps),)
+
+        self.label = self._instrument.s_parameter()
+        self.unit = _unit_map[self._instrument.display_format()]
+
+        self._instrument._traceready = True
+
+
+
+    def get_raw(self):
+        """
+        Return the trace
+        """
+        inst = self._instrument
+
+        if not inst._traceready:
+            raise TraceNotReady('Trace not ready. Please run prepare_trace.')
+
+        inst.write('CALC:DATA:FDAT') 
+        old_read_termination = inst.visa_handle.read_termination
+        try:
+            inst.visa_handle.read_termination = ''
+            raw_resp = inst.visa_handle.read_raw()
+        finally:
+            inst.visa_handle.read_termination = old_read_termination
+
+        first_points = B''
+        
+        for n in range((len(raw_resp)-4)//4):
+            first_points += raw_resp[4:][2*n*4:(2*n+1)*4]
+
+        dt = np.dtype('f')
+        trace1 = np.fromstring(first_points, dtype=dt)
+
 
 class CMTS5048(VisaInstrument):
-    # ... (code omitted for brevity)
+   """
+    This is the QCoDeS driver for the S5048 Network Analyzer
+    """
+
+    def __init__(self, name: str, address: str, **kwargs) -> None:
+        super().__init__(name, address, terminator='\n', **kwargs)
+
+        self.add_parameter(
+            'start_freq',
+            label='Sweep start frequency',
+            unit='Hz',
+            set_cmd=partial(self.invalidate_trace, 'SENS:FREQ:STAR {}'),
+            get_cmd='SENS:FREQ:STAR?',
+            get_parser=float,
+            vals=vals.Numbers(20000, 4800000000))
+
+        self.add_parameter(
+            'stop_freq',
+            label='Sweep stop frequency',
+            unit='Hz',
+            set_cmd=partial(self.invalidate_trace, 'SENS:FREQ:STOP {}'),
+            get_cmd='SENS:FREQ:STOP?',
+            get_parser=float,
+            vals=vals.Numbers(20000, 4800000000))
+
+        self.add_parameter(
+            'averaging',
+            label='Averaging state',
+            set_cmd='SENS:AVER{}',
+            get_cmd='SENS:AVER?',
+            val_mapping={'ON': 1, 'OFF': 0})
+
+        self.add_parameter(
+            'number_of_averages',
+            label='Number of averages',
+            set_cmd='SENS:AVER:COUN{}',
+            get_cmd='SENS:AVER:COUN?',
+            get_parser=CMTIntParser,
+            vals=vals.Ints(0, 999))
+
+        self.add_parameter(
+            'trace_points',
+            label='Number of points in trace',
+            set_cmd=partial(self.invalidate_trace, 'SENS:SWE:POIN{}'),
+            get_cmd='SENS:SWE:POIN?',
+            get_parser=CMTIntParser,
+            vals=vals.Enum(3, 11, 26, 51, 101, 201, 401,
+                           801, 1601))
+
+        self.add_parameter(
+            'sweep_time',
+            label='Sweep time',
+            set_cmd='SENS:SWE:POIN:TIME{}',
+            get_cmd='SENS:SWE:POIN:TIME?',
+            unit='s',
+            get_parser=float,
+            vals=vals.Numbers(0, 0.3),
+            )
+
+        self.add_parameter(
+            'output_power',
+            label='Output power',
+            unit='dBm',
+            set_cmd='SOUR:POW{}',
+            get_cmd='SOUR:POW?',
+            get_parser=float,
+            vals=vals.Numbers(-80, 20))
+        
+        self.add_parameter(
+            's_parameter',
+            label='S-parameter',
+            set_cmd=self._s_parameter_setter,
+            get_cmd=self._s_parameter_getter)
+
+
+        # DISPLAY / Y SCALE PARAMETERS
+        self.add_parameter(
+            'display_format',
+            label='Display format',
+            set_cmd=self._display_format_setter,
+            get_cmd=self._display_format_getter)
+
+        # TODO: update this on startup and via display format
+        self.add_parameter(
+            'display_reference',
+            label='Display reference level',
+            unit=None,  # will be set by display_format
+            get_cmd='DISP:WIND:TRAC:Y:RLEV?',
+            set_cmd='DISP:WIND:TRAC:Y:RLEV{}',
+            get_parser=float,
+            vals=vals.Numbers(-10e-18, 1e18))
+
+        self.add_parameter(
+            'display_scale',
+            label='Display scale',
+            unit=None,  # will be set by display_format
+            get_cmd='DISP:WIND:TRAC:Y:PDIV?',
+            set_cmd='DISP:WIND:TRAC:Y:PDIV{}',
+            get_parser=float,
+            vals=vals.Numbers(-10e-18, 1e18))
+
+        self.add_parameter(
+            name='trace',
+            parameter_class=CMTS5048Trace)
+
+        # Startup
+        self.startup()
+        self.connect_message()
+        
+
+    def reset(self) -> None:
+        """
+        Resets the instrument to factory default state
+        """
+        # use OPC to make sure we wait for operation to finish
+        self.ask('*OPC?;SYST:PRES')
+
+
+
+
+    def run_continously(self) -> None:
+        """
+        Set the instrument in run continously mode
+        """
+        self.write('INIT:CONT:ALL:ON')
+
+
+
+
+    def run_N_times(self, N: int) -> None
+        st = self.sweep_time.get_latest()
+
+        if N not in range(1, 1000):
+            raise ValueError('Can not run {} times.'.format(N) +
+                             ' please select a number from 1-999.')
+
+        # set a longer timeout, to not timeout during the sweep
+        new_timeout = 1000*st*N + 1000
+
+        with self.timeout.set_to(new_timeout):
+            log.debug(f'Making {N} blocking sweeps, setting VISA timeout to {new_timeout/1000} s.')
+            self.ask(f'*OPC?;NUMG{N}')
+
+
+
+
+    def invalidate_trace(self, cmd: str,
+                         value: Union[float, int, str]) -> None:
+        """
+        Wrapper for set_cmds that make the trace not ready
+        """
+        self._traceready = False
+        self.write(cmd.format(value))
+
+
+
+
+    def startup(self) -> None:
+        self._traceready = False
+        self.display_format(self.display_format())
+
+
+
+    def _s_parameter_setter(self, param: str) -> None:
+        """
+        set_cmd for the s_parameter parameter
+        """
+        allowed_s_params = {'S11', 'S12', 'S21', 'S22'}
+        if param not in allowed_s_params:
+            raise ValueError(f"Cannot set s-parameter to {param}, should be one of {allowed_s_params}")
+
+        # the trace labels changes
+        self._traceready = False
+
+        self.write(f"CALC:PAR:DEF \"{param}\"")
+
+    def _s_parameter_getter(self) -> str:
+        """
+        get_cmd for the s_parameter parameter
+        """
+        for cmd in ['S11', 'S12', 'S21', 'S22']:
+            resp = self.ask('CALC:PAR:DEF?')
+            if resp in ['1', '1\n']:
+                break
+
+        return cmd.replace('?', '')
+
+    def _display_format_setter(self, fmt: str) -> None:
+        """
+        set_cmd for the display_format parameter
+        """
+        val_mapping = {'Log Mag': 'MLOG',
+                       'Phase': 'PHAS',
+                       'Group Delay': 'GDEL',
+                       'Smith': 'SMIT',
+                       'Polar': 'POL',
+                       'Lin Mag': 'MLIN',
+                       'Real': 'REAL',
+                       'Imag': 'IMAG',
+                       'SWR': 'SWR'}
+
+        if fmt not in val_mapping:
+            raise ValueError(f"Cannot set display_format to {fmt}, should be one of {set(val_mapping.keys())}")
+
+        self._traceready = False
+        
+        self.display_reference.unit = _unit_map[fmt]
+        self.display_scale.unit = _unit_map[fmt] 
+        
+        self.write(f'CALC:FORM "{val_mapping[fmt]}"')
+
+    def _display_format_getter(self) -> str:
+        """
+        get_cmd for the display_format parameter
+        """
+        val_mapping = {'MLOG': 'Log Mag',
+                       'PHAS': 'Phase',
+                       'GDEL': 'Group Delay',
+                       'SMIT': 'Smith',
+                       'POL': 'Polar',
+                       'MLIN': 'Lin Mag',
+                       'REAL': 'Real',
+                       'IMAG': 'Imag',
+                       'SWR': 'SWR'}
+
+        # keep asking until we find the currently used format
+        for cmd in val_mapping:
+            resp = self.ask(f'CALC:FORM? "{cmd}"')
+            if resp in {'1', '1\n'}:
+                break
+
+        return val_mapping[cmd]
+
+
 
 # Create an instance of the S5048 Network Analyzer
 s5048 = CMTS5048('s5048', 'TCPIP0::192.168.1.1::inst0::INSTR')

--- a/docs/instruments-database/Oscilloscopes/Rigol-DS1074Z/Rigol-DS1074Z.md
+++ b/docs/instruments-database/Oscilloscopes/Rigol-DS1074Z/Rigol-DS1074Z.md
@@ -57,10 +57,13 @@ RIGOL’s line of products includes [digital storage oscilloscopes](https://www
 Here is a Python script that uses Qcodes to connect to a Rigol DS1074Z Oscilloscope:
 
 ```python
-from qcodes.instrument.visa import VisaInstrument
-
-class RigolDS1074Z(VisaInstrument):
-    # ... code omitted for brevity ...
+from qcodes.dataset import (
+    Measurement,
+    initialise_database,
+    load_or_create_experiment,
+    plot_dataset,
+)
+from qcodes.instrument_drivers.rigol import RigolDS1074Z
 
 # Create an instance of the RigolDS1074Z instrument
 rigol = RigolDS1074Z("rigol", "USB0::0x1AB1::0x04CE::DS1ZA222222222::INSTR")

--- a/docs/instruments-database/Power Supplies/D5a/D5a.md
+++ b/docs/instruments-database/Power Supplies/D5a/D5a.md
@@ -69,7 +69,101 @@ from functools import partial
 
 
 class D5a(Instrument):
-    # ... (the rest of the code provided in the question)
+
+    def __init__(self, name, spi_rack, module, inter_delay=0.1, dac_step=10e-3,
+                 reset_voltages=False, mV=False, number_dacs=16, **kwargs):
+                 
+        super().__init__(name, **kwargs)
+
+        self.d5a = D5a_module(spi_rack, module, reset_voltages=reset_voltages)
+        self._number_dacs = number_dacs
+
+        self._span_set_map = {
+            '4v uni': 0,
+            '4v bi': 2,
+            '2v bi': 4,
+        }
+
+        self._span_get_map = {v: k for k, v in self._span_set_map.items()}
+
+        self.add_function('set_dacs_zero', call_cmd=self._set_dacs_zero,
+                          docstring='Reset all dacs to zero voltage. No ramping is performed.')
+
+        if mV:
+            self._gain = 1e3
+            unit = 'mV'
+        else:
+            self._gain = 1
+            unit = 'V'
+
+        for i in range(self._number_dacs):
+            validator = self._get_validator(i)
+
+            self.add_parameter('dac{}'.format(i + 1),
+                               label='DAC {}'.format(i + 1),
+                               get_cmd=partial(self._get_dac, i),
+                               set_cmd=partial(self._set_dac, i),
+                               unit=unit,
+                               vals=validator,
+                               step=dac_step,
+                               inter_delay=inter_delay)
+
+            self.add_parameter('stepsize{}'.format(i + 1),
+                               get_cmd=partial(self.d5a.get_stepsize, i),
+                               unit='V',
+                               docstring='Returns the smallest voltage step of the DAC.')
+
+            self.add_parameter('span{}'.format(i + 1),
+                               get_cmd=partial(self._get_span, i),
+                               set_cmd=partial(self._set_span, i),
+                               vals=Enum(*self._span_set_map.keys()),
+                               docstring='Change the output span of the DAC. This command also updates the validator.')
+
+
+
+
+    def set_dac_unit(self, unit: str) -> None:
+        """Set the unit of dac parameters"""
+        allowed_values = Enum('mV', 'V')
+        allowed_values.validate(unit)
+        self._gain = {'V': 1, 'mV': 1e3}[unit]
+        for i in range(1, self._number_dacs + 1):
+            setattr(self.parameters[f'dac{i}'], 'unit', unit)
+            setattr(self.parameters[f'dac{i}'], 'vals', self._get_validator(i - 1))
+
+
+
+    def _set_dacs_zero(self):
+        for i in range(self._number_dacs):
+            self._set_dac(i, 0.0)
+
+    def _set_dac(self, dac, value):
+        return self.d5a.set_voltage(dac, value / self._gain)
+
+    def _get_dac(self, dac):
+        return self._gain * self.d5a.voltages[dac]
+
+    def _get_span(self, dac):
+        return self._span_get_map[self.d5a.span[dac]]
+
+    def _set_span(self, dac, span_str):
+        self.d5a.change_span_update(dac, self._span_set_map[span_str])
+        self.parameters['dac{}'.format(
+            dac + 1)].vals = self._get_validator(dac)
+
+    def _get_validator(self, dac):
+        span = self.d5a.span[dac]
+        if span == D5a_module.range_2V_bi:
+            validator = Numbers(-2 * self._gain, 2 * self._gain)
+        elif span == D5a_module.range_4V_bi:
+            validator = Numbers(-4 * self._gain, 4 * self._gain)
+        elif span == D5a_module.range_4V_uni:
+            validator = Numbers(0, 4 * self._gain)
+        else:
+            msg = 'The found DAC span of {} does not correspond to a known one'
+            raise Exception(msg.format(span))
+
+        return validator
 
 # Create an instance of the SPI_rack class
 spi_rack = SPI_rack("SPI_rack", "COM1")  # Replace "COM1" with the appropriate port name

--- a/docs/instruments-database/Power Supplies/PL155-P/PL155-P.md
+++ b/docs/instruments-database/Power Supplies/PL155-P/PL155-P.md
@@ -55,14 +55,315 @@ TTi (Thurlby Thandar Instruments) is a leading manufacturer of electronic test a
 Here is a Python script that uses Qcodes to connect to a PL155-P Power Supply:
 
 ```python
-from qcodes.instrument.visa import VisaInstrument
-from qcodes.instrument.channel import ChannelList
+from typing import Any, Optional
 
-class AimTTiChannel(VisaInstrument):
-    # Define the parameters and methods for the channel
+from qcodes import validators as vals
+from qcodes.instrument import ChannelList, Instrument, InstrumentChannel, VisaInstrument
+from qcodes.parameters import create_on_off_val_mapping
+
+
+class NotKnownModel(Exception):
+    """
+    An Error thrown when connecting to an unknown Aim TTi model
+    """
+
+    pass
+
+
+class AimTTiChannel(InstrumentChannel):
+    """
+    This is the class that holds the output channels of AimTTi power
+    supply.
+    """
+
+    def __init__(
+        self, parent: Instrument, name: str, channel: int, **kwargs: Any
+    ) -> None:
+        """
+        Args:
+            parent: The Instrument instance to which the channel is
+                to be attached.
+            name: The 'colloquial' name of the channel.
+            channel: The name used by the AimTTi.
+        """
+        super().__init__(parent, name, **kwargs)
+
+        self.channel = channel
+        self.set_up_store_slots = [i for i in range(0, 10)]
+
+        self.add_parameter(
+            "volt",
+            get_cmd=self._get_voltage_value,
+            get_parser=float,
+            set_cmd=f"V{channel} {{}}",
+            label="Voltage",
+            unit="V",
+        )
+
+        self.add_parameter(
+            "volt_step_size",
+            get_cmd=self._get_voltage_step_size,
+            get_parser=float,
+            set_cmd=f"DELTAV{channel} {{}}",
+            label="Voltage Step Size",
+            unit="V",
+        )
+
+        self.add_parameter(
+            "curr",
+            get_cmd=self._get_current_value,
+            get_parser=float,
+            set_cmd=f"I{channel} {{}}",
+            label="Current",
+            unit="A",
+        )
+
+        self.add_parameter(
+            "curr_range",
+            get_cmd=f"IRANGE{channel}?",
+            get_parser=int,
+            set_cmd=self._set_current_range,
+            label="Current Range",
+            unit="A",
+            vals=vals.Numbers(1, 2),
+            docstring="Set the current range of the output."
+            "Here, the integer 1 is for the Low range, "
+            "and integer 2 is for the High range.",
+        )
+
+        self.add_parameter(
+            "curr_step_size",
+            get_cmd=self._get_current_step_size,
+            get_parser=float,
+            set_cmd=f"DELTAI{channel} {{}}",
+            label="Current Step Size",
+            unit="A",
+        )
+
+        self.add_parameter(
+            "output",
+            get_cmd=f"OP{channel}?",
+            get_parser=float,
+            set_cmd=f"OP{channel} {{}}",
+            val_mapping=create_on_off_val_mapping(on_val=1, off_val=0),
+        )
+
+    def _get_voltage_value(self) -> float:
+        channel_id = self.channel
+        _voltage = self.ask_raw(f"V{channel_id}?")
+        _voltage_split = _voltage.split()
+        return float(_voltage_split[1])
+
+    def _get_current_value(self) -> float:
+        channel_id = self.channel
+        _current = self.ask_raw(f"I{channel_id}?")
+        _current_split = _current.split()
+        return float(_current_split[1])
+
+    def _get_voltage_step_size(self) -> float:
+        channel_id = self.channel
+        _voltage_step_size = self.ask_raw(f"DELTAV{channel_id}?")
+        _v_step_size_split = _voltage_step_size.split()
+        return float(_v_step_size_split[1])
+
+    def _get_current_step_size(self) -> float:
+        channel_id = self.channel
+        _current_step_size = self.ask_raw(f"DELTAI{channel_id}?")
+        _c_step_size_split = _current_step_size.split()
+        return float(_c_step_size_split[1])
+
+    def _set_current_range(self, val: int) -> None:
+        channel_id = self.channel
+        with self.output.set_to(False):
+            self.write(f"IRANGE{channel_id} {val}")
+
+    def increment_volt_by_step_size(self) -> None:
+        """
+        A bound method that increases the voltage output of the corresponding
+        channel by an amount the step size set by the user via ``volt_step_size``
+        parameter.
+        """
+        channel_id = self.channel
+        self.write(f"INCV{channel_id}")
+        # Clear the cache.
+        _ = self.volt.get()
+
+    def decrement_volt_by_step_size(self) -> None:
+        """
+        A bound method that decreases the voltage output of the corresponding
+        channel by an amount the step size set by the user via ``volt_step_size``
+        parameter.
+        """
+        channel_id = self.channel
+        self.write(f"DECV{channel_id}")
+        # Clear the cache.
+        _ = self.volt.get()
+
+    def increment_curr_by_step_size(self) -> None:
+        """
+        A bound method that increases the current output of the corresponding
+        channel by an amount the step size set by the user via ``curr_step_size``
+        parameter.
+        """
+        channel_id = self.channel
+        self.write(f"INCI{channel_id}")
+        # Clear the cache.
+        _ = self.curr.get()
+
+    def decrement_curr_by_step_size(self) -> None:
+        """
+        A bound method that decreases the current output of the corresponding
+        channel by an amount the step size set by the user via ``curr_step_size``
+        parameter.
+        """
+        channel_id = self.channel
+        self.write(f"DECI{channel_id}")
+        # Clear the cache.
+        _ = self.curr.get()
+
+    def save_setup(self, slot: int) -> None:
+        if slot not in self.set_up_store_slots:
+            raise RuntimeError("Slote number should be an integer between" "0 adn 9.")
+
+        channel_id = self.channel
+        self.write(f"SAV{channel_id} {slot}")
+
+    def load_setup(self, slot: int) -> None:
+        if slot not in self.set_up_store_slots:
+            raise RuntimeError("Slote number should be an integer between" "0 adn 9.")
+
+        channel_id = self.channel
+        self.write(f"RCL{channel_id} {slot}")
+        # Update snapshot after load.
+        _ = self.snapshot(update=True)
+
+    def set_damping(self, val: int) -> None:
+        """
+        Sets the current meter measurement averaging on and off.
+        """
+        if val not in [0, 1]:
+            raise RuntimeError(
+                "To 'turn on' and 'turn off' the averaging, "
+                "use '1' and '0', respectively."
+            )
+        channel_id = self.channel
+        self.write(f"DAMPING{channel_id} {val}")
+
 
 class AimTTi(VisaInstrument):
-    # Define the parameters and methods for the power supply
+    """
+    This is the QCoDeS driver for the Aim TTi PL-P series power supply.
+    Tested with Aim TTi PL601-P equipped with a single output channel.
+    """
+
+    _numOutputChannels = {
+        "PL068-P": 1,
+        "PL155-P": 1,
+        "PL303-P": 1,
+        "PL601-P": 1,
+        "PL303QMD-P": 2,
+        "PL303QMT-P": 3,
+        "QL355TP": 3,
+    }
+
+    def __init__(self, name: str, address: str, **kwargs: Any) -> None:
+        """
+        Args:
+            name: Name to use internally in QCoDeS.
+            address: VISA resource address
+        """
+        super().__init__(name, address, terminator="\n", **kwargs)
+
+        channels = ChannelList(self, "Channels", AimTTiChannel, snapshotable=False)
+
+        _model = self.get_idn()["model"]
+
+        if (_model not in self._numOutputChannels.keys()) or (_model is None):
+            raise NotKnownModel("Unknown model, connection cannot be " "established.")
+
+        self.numOfChannels = self._numOutputChannels[_model]
+        for i in range(1, self.numOfChannels + 1):
+            channel = AimTTiChannel(self, f"ch{i}", i)
+            channels.append(channel)
+            self.add_submodule(f"ch{i}", channel)
+
+        self.add_submodule("channels", channels.to_channel_tuple())
+        self.connect_message()
+
+    # Interface Management
+
+    def get_idn(self) -> dict[str, Optional[str]]:
+        """
+        Returns the instrument identification including vendor, model, serial
+        number and the firmware.
+        """
+        IDNstr = self.ask_raw("*IDN?")
+        vendor, model, serial, firmware = map(str.strip, IDNstr.split(","))
+
+        IDN: dict[str, Optional[str]] = {
+            "vendor": vendor,
+            "model": model,
+            "serial": serial,
+            "firmware": firmware,
+        }
+        return IDN
+
+    def get_address(self) -> int:
+        """
+        Returns the bus address.
+        """
+        busAddressStr = self.ask_raw("ADDRESS?")
+        busAddress = busAddressStr.strip()
+        return int(busAddress)
+
+    def get_IP(self) -> str:
+        ipAddress = self.ask_raw("IPADDR?")
+        return ipAddress.strip()
+
+    def get_netMask(self) -> str:
+        """
+        Returns the netmask of the LAN interface, if the connection exists.
+        """
+        netMask = self.ask_raw("NETMASK?")
+        return netMask.strip()
+
+    def get_netConfig(self) -> str:
+        """
+        Returns the means by which an IP address is acquired, i.e.,
+        DHCP, AUTO or STATIC.
+        """
+        netConfig = self.ask_raw("NETCONFIG?")
+        return netConfig.strip()
+
+    def local_mode(self) -> None:
+        """
+        Go to local mode until the next remote command is recieved. This
+        function does not release any active interface lock.
+        """
+        self.write("LOCAL")
+
+    def is_interface_locked(self) -> int:
+        is_lockedSTR = self.ask_raw("IFLOCK?")
+        is_locked = is_lockedSTR.strip()
+        return int(is_locked)
+
+    def lock_interface(self) -> int:
+        """
+        Requests instrument interface lock. Returns '1' if successful and
+        '-1' if the lock is unavailable.
+        """
+        lockSTR = self.ask_raw("IFLOCK")
+        lock = lockSTR.strip()
+        return int(lock)
+
+    def unlock_interface(self) -> int:
+        """
+        Requests the release of instrument interface lock. Returns '0'
+        if successful and '-1' if unsuccessful.
+        """
+        unlockSTR = self.ask_raw("IFUNLOCK")
+        unlock = unlockSTR.strip()
+        return int(unlock)
 
 # Create an instance of the power supply
 power_supply = AimTTi('power_supply', 'TCPIP::192.168.1.1::INSTR')

--- a/docs/instruments-database/Power Supplies/PL601-P/PL601-P.md
+++ b/docs/instruments-database/Power Supplies/PL601-P/PL601-P.md
@@ -55,15 +55,315 @@ TTi (Thurlby Thandar Instruments) is a leading manufacturer of electronic test a
 To connect to a PL601-P Power Supply using Qcodes, you can use the following Python script:
 
 ```python
-from qcodes.instrument.visa import VisaInstrument
-from qcodes.instrument.channel import ChannelList
+from typing import Any, Optional
 
-class AimTTiChannel(VisaInstrument):
-    # ... implementation of AimTTiChannel class ...
+from qcodes import validators as vals
+from qcodes.instrument import ChannelList, Instrument, InstrumentChannel, VisaInstrument
+from qcodes.parameters import create_on_off_val_mapping
+
+
+class NotKnownModel(Exception):
+    """
+    An Error thrown when connecting to an unknown Aim TTi model
+    """
+
+    pass
+
+
+class AimTTiChannel(InstrumentChannel):
+    """
+    This is the class that holds the output channels of AimTTi power
+    supply.
+    """
+
+    def __init__(
+        self, parent: Instrument, name: str, channel: int, **kwargs: Any
+    ) -> None:
+        """
+        Args:
+            parent: The Instrument instance to which the channel is
+                to be attached.
+            name: The 'colloquial' name of the channel.
+            channel: The name used by the AimTTi.
+        """
+        super().__init__(parent, name, **kwargs)
+
+        self.channel = channel
+        self.set_up_store_slots = [i for i in range(0, 10)]
+
+        self.add_parameter(
+            "volt",
+            get_cmd=self._get_voltage_value,
+            get_parser=float,
+            set_cmd=f"V{channel} {{}}",
+            label="Voltage",
+            unit="V",
+        )
+
+        self.add_parameter(
+            "volt_step_size",
+            get_cmd=self._get_voltage_step_size,
+            get_parser=float,
+            set_cmd=f"DELTAV{channel} {{}}",
+            label="Voltage Step Size",
+            unit="V",
+        )
+
+        self.add_parameter(
+            "curr",
+            get_cmd=self._get_current_value,
+            get_parser=float,
+            set_cmd=f"I{channel} {{}}",
+            label="Current",
+            unit="A",
+        )
+
+        self.add_parameter(
+            "curr_range",
+            get_cmd=f"IRANGE{channel}?",
+            get_parser=int,
+            set_cmd=self._set_current_range,
+            label="Current Range",
+            unit="A",
+            vals=vals.Numbers(1, 2),
+            docstring="Set the current range of the output."
+            "Here, the integer 1 is for the Low range, "
+            "and integer 2 is for the High range.",
+        )
+
+        self.add_parameter(
+            "curr_step_size",
+            get_cmd=self._get_current_step_size,
+            get_parser=float,
+            set_cmd=f"DELTAI{channel} {{}}",
+            label="Current Step Size",
+            unit="A",
+        )
+
+        self.add_parameter(
+            "output",
+            get_cmd=f"OP{channel}?",
+            get_parser=float,
+            set_cmd=f"OP{channel} {{}}",
+            val_mapping=create_on_off_val_mapping(on_val=1, off_val=0),
+        )
+
+    def _get_voltage_value(self) -> float:
+        channel_id = self.channel
+        _voltage = self.ask_raw(f"V{channel_id}?")
+        _voltage_split = _voltage.split()
+        return float(_voltage_split[1])
+
+    def _get_current_value(self) -> float:
+        channel_id = self.channel
+        _current = self.ask_raw(f"I{channel_id}?")
+        _current_split = _current.split()
+        return float(_current_split[1])
+
+    def _get_voltage_step_size(self) -> float:
+        channel_id = self.channel
+        _voltage_step_size = self.ask_raw(f"DELTAV{channel_id}?")
+        _v_step_size_split = _voltage_step_size.split()
+        return float(_v_step_size_split[1])
+
+    def _get_current_step_size(self) -> float:
+        channel_id = self.channel
+        _current_step_size = self.ask_raw(f"DELTAI{channel_id}?")
+        _c_step_size_split = _current_step_size.split()
+        return float(_c_step_size_split[1])
+
+    def _set_current_range(self, val: int) -> None:
+        channel_id = self.channel
+        with self.output.set_to(False):
+            self.write(f"IRANGE{channel_id} {val}")
+
+    def increment_volt_by_step_size(self) -> None:
+        """
+        A bound method that increases the voltage output of the corresponding
+        channel by an amount the step size set by the user via ``volt_step_size``
+        parameter.
+        """
+        channel_id = self.channel
+        self.write(f"INCV{channel_id}")
+        # Clear the cache.
+        _ = self.volt.get()
+
+    def decrement_volt_by_step_size(self) -> None:
+        """
+        A bound method that decreases the voltage output of the corresponding
+        channel by an amount the step size set by the user via ``volt_step_size``
+        parameter.
+        """
+        channel_id = self.channel
+        self.write(f"DECV{channel_id}")
+        # Clear the cache.
+        _ = self.volt.get()
+
+    def increment_curr_by_step_size(self) -> None:
+        """
+        A bound method that increases the current output of the corresponding
+        channel by an amount the step size set by the user via ``curr_step_size``
+        parameter.
+        """
+        channel_id = self.channel
+        self.write(f"INCI{channel_id}")
+        # Clear the cache.
+        _ = self.curr.get()
+
+    def decrement_curr_by_step_size(self) -> None:
+        """
+        A bound method that decreases the current output of the corresponding
+        channel by an amount the step size set by the user via ``curr_step_size``
+        parameter.
+        """
+        channel_id = self.channel
+        self.write(f"DECI{channel_id}")
+        # Clear the cache.
+        _ = self.curr.get()
+
+    def save_setup(self, slot: int) -> None:
+        if slot not in self.set_up_store_slots:
+            raise RuntimeError("Slote number should be an integer between" "0 adn 9.")
+
+        channel_id = self.channel
+        self.write(f"SAV{channel_id} {slot}")
+
+    def load_setup(self, slot: int) -> None:
+        if slot not in self.set_up_store_slots:
+            raise RuntimeError("Slote number should be an integer between" "0 adn 9.")
+
+        channel_id = self.channel
+        self.write(f"RCL{channel_id} {slot}")
+        # Update snapshot after load.
+        _ = self.snapshot(update=True)
+
+    def set_damping(self, val: int) -> None:
+        """
+        Sets the current meter measurement averaging on and off.
+        """
+        if val not in [0, 1]:
+            raise RuntimeError(
+                "To 'turn on' and 'turn off' the averaging, "
+                "use '1' and '0', respectively."
+            )
+        channel_id = self.channel
+        self.write(f"DAMPING{channel_id} {val}")
+
 
 class AimTTi(VisaInstrument):
-    # ... implementation of AimTTi class ...
+    """
+    This is the QCoDeS driver for the Aim TTi PL-P series power supply.
+    Tested with Aim TTi PL601-P equipped with a single output channel.
+    """
 
+    _numOutputChannels = {
+        "PL068-P": 1,
+        "PL155-P": 1,
+        "PL303-P": 1,
+        "PL601-P": 1,
+        "PL303QMD-P": 2,
+        "PL303QMT-P": 3,
+        "QL355TP": 3,
+    }
+
+    def __init__(self, name: str, address: str, **kwargs: Any) -> None:
+        """
+        Args:
+            name: Name to use internally in QCoDeS.
+            address: VISA resource address
+        """
+        super().__init__(name, address, terminator="\n", **kwargs)
+
+        channels = ChannelList(self, "Channels", AimTTiChannel, snapshotable=False)
+
+        _model = self.get_idn()["model"]
+
+        if (_model not in self._numOutputChannels.keys()) or (_model is None):
+            raise NotKnownModel("Unknown model, connection cannot be " "established.")
+
+        self.numOfChannels = self._numOutputChannels[_model]
+        for i in range(1, self.numOfChannels + 1):
+            channel = AimTTiChannel(self, f"ch{i}", i)
+            channels.append(channel)
+            self.add_submodule(f"ch{i}", channel)
+
+        self.add_submodule("channels", channels.to_channel_tuple())
+        self.connect_message()
+
+    # Interface Management
+
+    def get_idn(self) -> dict[str, Optional[str]]:
+        """
+        Returns the instrument identification including vendor, model, serial
+        number and the firmware.
+        """
+        IDNstr = self.ask_raw("*IDN?")
+        vendor, model, serial, firmware = map(str.strip, IDNstr.split(","))
+
+        IDN: dict[str, Optional[str]] = {
+            "vendor": vendor,
+            "model": model,
+            "serial": serial,
+            "firmware": firmware,
+        }
+        return IDN
+
+    def get_address(self) -> int:
+        """
+        Returns the bus address.
+        """
+        busAddressStr = self.ask_raw("ADDRESS?")
+        busAddress = busAddressStr.strip()
+        return int(busAddress)
+
+    def get_IP(self) -> str:
+        ipAddress = self.ask_raw("IPADDR?")
+        return ipAddress.strip()
+
+    def get_netMask(self) -> str:
+        """
+        Returns the netmask of the LAN interface, if the connection exists.
+        """
+        netMask = self.ask_raw("NETMASK?")
+        return netMask.strip()
+
+    def get_netConfig(self) -> str:
+        """
+        Returns the means by which an IP address is acquired, i.e.,
+        DHCP, AUTO or STATIC.
+        """
+        netConfig = self.ask_raw("NETCONFIG?")
+        return netConfig.strip()
+
+    def local_mode(self) -> None:
+        """
+        Go to local mode until the next remote command is recieved. This
+        function does not release any active interface lock.
+        """
+        self.write("LOCAL")
+
+    def is_interface_locked(self) -> int:
+        is_lockedSTR = self.ask_raw("IFLOCK?")
+        is_locked = is_lockedSTR.strip()
+        return int(is_locked)
+
+    def lock_interface(self) -> int:
+        """
+        Requests instrument interface lock. Returns '1' if successful and
+        '-1' if the lock is unavailable.
+        """
+        lockSTR = self.ask_raw("IFLOCK")
+        lock = lockSTR.strip()
+        return int(lock)
+
+    def unlock_interface(self) -> int:
+        """
+        Requests the release of instrument interface lock. Returns '0'
+        if successful and '-1' if unsuccessful.
+        """
+        unlockSTR = self.ask_raw("IFUNLOCK")
+        unlock = unlockSTR.strip()
+        return int(unlock)
 # Create an instance of the AimTTi instrument
 aim_tti = AimTTi('aim_tti', 'TCPIP0::192.168.1.1::inst0::INSTR')
 

--- a/docs/instruments-database/RF Signal Generators/S5i/S5i.md
+++ b/docs/instruments-database/RF Signal Generators/S5i/S5i.md
@@ -57,10 +57,88 @@ To connect to an S5i RF Signal Generator using Qcodes Community, you can use the
 ```python
 from qcodes.instrument.base import Instrument
 from qcodes.utils.validators import Bool, Numbers
-from spirack import S5i_module
+try:
+    from spirack import S5i_module
+except ImportError:
+    raise ImportError(('The S5i_module class could not be found. '
+                       'Try installing it using pip install spirack'))
 
 class S5i(Instrument):
-    # ... (same code as provided in the question)
+    """
+    Qcodes driver for the S5i RF generator SPI-rack module.
+
+    Args:
+        name (str): name of the instrument.
+        spi_rack (SPI_rack): instance of the SPI_rack class as defined in
+            the spirack package. This class manages communication with the
+            individual modules.
+        module (int): module number as set on the hardware.
+        frequency (float): RF frequency at startup, default is 41 MHz.
+        enable_output (bool): Switch device output on or off, default is True.
+        output_level (int): RF output level in dBm, default is 0 dBm.
+    """
+
+    def __init__(self, name, spi_rack, module, frequency=41e6,
+                 enable_output=True, output_level=0, **kwargs):
+        super().__init__(name, **kwargs)
+
+        self.s5i = S5i_module(spi_rack, module, frequency=frequency,
+                              enable_output=enable_output,
+                              output_level=output_level)
+
+        self.add_parameter('output_enabled',
+                           label='RF output enabled',
+                           initial_value=enable_output,
+                           set_cmd=self.s5i.enable_output_soft,
+                           vals=Bool(),
+                           docstring='Switches output on/off')
+
+        self.add_parameter('frequency_stepsize',
+                           label='Frequency stepsize',
+                           get_cmd=self._get_stepsize,
+                           set_cmd=self.s5i.set_stepsize,
+                           unit='Hz',
+                           vals=Numbers(),
+                           docstring='Set the optimal frequency stepsize for '
+                                     'a minimal phase noise')
+
+        self.add_parameter('frequency',
+                           label='Frequency',
+                           initial_value=frequency,
+                           get_cmd=self._get_rf_frequency,
+                           set_cmd=self.s5i.set_frequency,
+                           unit='Hz',
+                           vals=Numbers(40e6, 4e9),
+                           docstring='Set RF frequency')
+
+        self.add_parameter('power',
+                           label='Output Power',
+                           initial_value=output_level,
+                           set_cmd=self.s5i.set_output_power,
+                           unit='dBm',
+                           vals=Numbers(-14, 20),
+                           docstring='Set output power')
+
+
+    def optimize_for_frequency(self):
+        """
+        This method finds the optimum stepsize for the set frequency.
+
+        The stepsize affects the phase noise of the instrument. The smaller the
+        stepsize, the greater is the phase noise. So this method sets the
+        stepsize as large as possible for the current reference frequency.
+
+        """
+        stepsize = self.s5i.get_optimal_stepsize(self.s5i.rf_frequency)
+        self.s5i.set_stepsize(stepsize)
+
+
+
+    def _get_stepsize(self):
+        return self.s5i.stepsize
+
+    def _get_rf_frequency(self):
+        return self.s5i.rf_frequency
 
 # Create an instance of the SPI_rack class from the spirack package
 spi_rack = SPI_rack()


### PR DESCRIPTION
These instruments still have incorrect syntax as they did not pass the `ast.parser`.

M2j
S5048 2-Port 4.8 GHz Analyzer
 Keysight 86100A
 
 In order to validate that these snippets have proper syntax:
 
 Run the code cell for "Instrument pages"
<img width="1091" alt="Screenshot 2023-08-31 at 5 28 04 PM" src="https://github.com/flojoy-ai/docs/assets/83793112/309f6022-13af-4f4a-a8bf-5721e5bc932a">

of the `Docusaurus_Generation.ipynb` in `gpt-doc-gen` repo