### PR TITLE
Fixed installation error in docs

### DIFF
--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -153,7 +153,7 @@ python3.10 -m venv venv
 5. Finally, run:
 
 ```bash
-bash flojoy -v venv -p
+bash flojoy -v venv
 ```
 
 Optional flags:


### PR DESCRIPTION
Fixed "Advanced: Install manually from source" errors.

"-p" flag shouldn't be used in the first installation.

